### PR TITLE
vc_infer_pipeline.py: switch to int

### DIFF
--- a/vc_infer_pipeline.py
+++ b/vc_infer_pipeline.py
@@ -359,7 +359,7 @@ class VC(object):
         ) + 1
         f0_mel[f0_mel <= 1] = 1
         f0_mel[f0_mel > 255] = 255
-        f0_coarse = np.rint(f0_mel).astype(np.int)
+        f0_coarse = np.rint(f0_mel).astype(int)
 
         return f0_coarse, f0bak  # 1-0
 


### PR DESCRIPTION
`np.int` is deprecated, switch to `int` (fixes the error when inferring)